### PR TITLE
feat: 검색결과, 마커 클릭 시 지도 이동 후 오버레이 생성

### DIFF
--- a/src/pages/Map/Map.tsx
+++ b/src/pages/Map/Map.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useRef, useState } from 'react';
-import { useRecoilValue } from 'recoil';
-import { useParams } from 'react-router-dom';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import * as ReactDOMServer from 'react-dom/server';
+import { useNavigate, useParams } from 'react-router-dom';
 
+import { useRecoilValue } from 'recoil';
 import { dbState, IdbState } from '../../store/selectors';
 
 import * as S from './Map.style';
 
 import InfoWrapper from './InfoWrapper/InfoWrapper';
+import Overlay from './Overlay/Overlay';
 
 const { kakao } = window;
 
@@ -18,6 +20,9 @@ declare global {
 }
 
 export default function Map() {
+  const navigate = useNavigate();
+
+  // URL 파라미터 가져오기
   const { bookstoreId } = useParams();
 
   // 전역 DB 불러오기
@@ -26,11 +31,14 @@ export default function Map() {
   // 지도가 표시될 HTML element
   const mapContainer = useRef(null);
 
-  // map을 자식 컴포넌트에 props로  넘김
+  // map 객체를 저장할 state
   const [map, setMap] = useState<any>(null);
 
+  // 현재 클릭한 bookstroreId를 저장할 state
+  const [selectedStoreId, setSelectedStoreId] = useState<any>(null);
+
   // 카카오 지도 생성하기, 마커 표시하기
-  const handleMap = () => {
+  const handleMap = useCallback(() => {
     // 지도를 생성할 때 필요한 기본 옵션
     let options = {
       center: new kakao.maps.LatLng(37.56839464, 126.9303023), // 지도의 중심 좌표
@@ -57,46 +65,60 @@ export default function Map() {
         title: store.FCLTY_NM, // 마커의 타이틀, 마커에 마우스를 올리면 타이틀이 표시됨
         position: new kakao.maps.LatLng(store.FCLTY_LA, store.FCLTY_LO), // 마커를 표시할 위치(위도, 경도)
         image: markerImage, // 커스텀 마커 이미지 설정
+        id: store.ESNTL_ID, // 마커에 ESNTL_ID를 id로 설정
       });
 
       // 마커 클릭 이벤트
-      kakao.maps.event.addListener(marker, 'click', function () {
-        // 클릭한 마커의 좌표를 반환함
-        const markerPosition = marker.getPosition();
-
-        // 마커 클릭 시 이동 좌표 지정
-        const moveLatLon = new kakao.maps.LatLng(
-          markerPosition.Ma,
-          markerPosition.La,
-        );
-
-        // 지도 중심을 부드럽게 이동함
-        map.panTo(moveLatLon);
-        // map.setLevel(4); // 지도 확대 레벨 설정
-      });
+      kakao.maps.event.addListener(marker, 'click', () =>
+        navigate(`/map/${store.ESNTL_ID}`),
+      );
     });
-  };
+  }, [DB]);
 
   useEffect(() => {
     handleMap();
-  }, [DB]);
+  }, [DB, handleMap]);
 
   // 라우터 파라미터로 받은 bookstoreId 값에 따라 지도 이동
   useEffect(() => {
+    // 지도가 생성되지 않았으면 함수 종료
     if (!map) return;
+    // bookstoreId가 없으면 지도 중심 좌표를 서울로 이동
+    if (!bookstoreId) {
+      map.panTo(new kakao.maps.LatLng(37.56839464, 126.9303023));
+      map.setLevel(10);
+    }
 
-    DB.find((store) => {
+    // 이전에 클릭한 마커가 있으면 지도에서 제거
+    const prevStore = selectedStoreId;
+    prevStore && prevStore.setMap(null);
+
+    // bookstoreId에 해당하는 마커로 지도 이동
+    DB.forEach((store) => {
       if (store.ESNTL_ID === bookstoreId) {
         const moveLatLon = new kakao.maps.LatLng(
           store.FCLTY_LA,
           store.FCLTY_LO,
         );
-        map.panTo(moveLatLon);
-      }
+        map.setLevel(6); // 지도 확대 레벨 설정
+        map.panTo(moveLatLon); // 지도 중심 좌표 이동
 
-      return store.FCLTY_NM === bookstoreId;
+        // 커스텀 오버레이 생성
+        const overlayContent = ReactDOMServer.renderToString(
+          <Overlay info={store} />,
+        );
+        const overlay = new kakao.maps.CustomOverlay({
+          content: overlayContent,
+          map: map,
+          position: moveLatLon,
+          xAnchor: 0.5,
+          yAnchor: 0.5,
+        });
+
+        setSelectedStoreId(overlay);
+      }
     });
-  }, [map, bookstoreId, DB]);
+  }, [bookstoreId, map, DB]);
 
   return (
     <S.Container>

--- a/src/pages/Map/Overlay/Overlay.style.tsx
+++ b/src/pages/Map/Overlay/Overlay.style.tsx
@@ -1,0 +1,76 @@
+import styled from 'styled-components';
+import { BLACK_COLOR, PINK_COLOR, WHITE_COLOR } from '../../../common/colors';
+
+export const Overlay = styled.div`
+  position: absolute;
+  background-color: ${WHITE_COLOR};
+  opacity: 0.9;
+  z-index: 3;
+  width: 400px;
+  left: -200px;
+  top: -280px;
+  padding: 1rem;
+  border: 1px solid ${BLACK_COLOR};
+  border-radius: 0.5rem;
+`;
+
+export const NameRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+`;
+
+export const Name = styled.span`
+  margin-right: 0.5rem;
+  transition: 80ms ease-in-out;
+  &:hover {
+    color: ${PINK_COLOR};
+  }
+`;
+
+export const IconsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin-right: 0.5rem;
+`;
+
+export const Category = styled.div`
+  font-size: 0.9rem;
+  border-radius: 6px;
+  border: 1px solid ${BLACK_COLOR};
+  padding: 0.2rem 0.5rem;
+`;
+
+export const Address = styled.div`
+  padding-bottom: 1rem;
+  font-size: 0.9rem;
+`;
+
+export const Description = styled.div`
+  font-size: 0.9rem;
+  color: ${BLACK_COLOR};
+  margin-bottom: 1rem;
+`;
+
+export const Row = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 0.8rem;
+  line-height: 1.3;
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+export const RowHeader = styled.div`
+  color: ${BLACK_COLOR};
+  min-width: 70px;
+  margin-right: 1rem;
+`;
+
+export const RowContent = styled.div`
+  font-size: 0.9rem;
+  color: ${BLACK_COLOR};
+`;

--- a/src/pages/Map/Overlay/Overlay.tsx
+++ b/src/pages/Map/Overlay/Overlay.tsx
@@ -1,0 +1,54 @@
+import { FaParking } from 'react-icons/fa';
+import { IoCafeOutline } from 'react-icons/io5';
+import { MdCircle } from 'react-icons/md';
+import { LIGHT_GRAY_COLOR } from '../../../common/colors';
+import * as S from './Overlay.style';
+
+export default function Overlay({ info }: any) {
+  const {
+    FCLTY_NM: name,
+    MLSFC_NM: category,
+    FCLTY_ROAD_NM_ADDR: address,
+    OPTN_DC: description,
+  } = info;
+
+  return (
+    <S.Overlay>
+      <S.NameRow>
+        <S.IconsContainer>
+          <MdCircle
+            style={{
+              color: LIGHT_GRAY_COLOR,
+              marginRight: '0.5rem',
+            }}
+          />
+          <S.Name>{name}</S.Name>
+          <FaParking style={{ marginRight: '0.2rem' }} />
+          <IoCafeOutline />
+        </S.IconsContainer>
+        <S.Category>{category}</S.Category>
+      </S.NameRow>
+      <S.Description>{description}</S.Description>
+
+      <S.Row>
+        <S.RowHeader>주소</S.RowHeader>
+        <S.RowContent>{address}</S.RowContent>
+      </S.Row>
+      <S.Row>
+        <S.RowHeader>운영시간</S.RowHeader>
+        <S.RowContent>
+          <div>평일 9시~18시</div>
+          <div>주말 9시~18시</div>
+        </S.RowContent>
+      </S.Row>
+      <S.Row>
+        <S.RowHeader>휴무</S.RowHeader>
+        <S.RowContent>목요일 14:00~20:00, 일요일 정기휴무</S.RowContent>
+      </S.Row>
+      <S.Row>
+        <S.RowHeader>전화</S.RowHeader>
+        <S.RowContent>02)064-722-2654</S.RowContent>
+      </S.Row>
+    </S.Overlay>
+  );
+}


### PR DESCRIPTION
## 개요 🔎

* 검색결과 또는 마커를 클릭 시, 지도 이동 후 오버레이 생성하는 기능을 추가했습니다.

## 작업사항 📝

* Overlay 컴포넌트를 생성했습니다.
* 마커 클릭 이벤트를 변경했습니다.
  * 기존: 지도 이동 -> 변경 후: 라우터에 파라미터 전달
    ```
    kakao.maps.event.addListener(marker, 'click', () =>
      navigate(`/map/${store.ESNTL_ID}`),
    );
    ```
* 라우터 변경 시 지도를 이동하는 기능을 추가했습니다.
  * `bookstoreId`가 있을 경우, 지도 확대 & 해당 서점 좌표로 이동 후 오버레이 표시
  * `bookstroeId`가 없을 경우 (/map 경로), 초기 좌표로 이동 후 축적 리셋

## 패키지 설치내용 📦

none